### PR TITLE
Add simple journal website

### DIFF
--- a/journal_app.py
+++ b/journal_app.py
@@ -1,0 +1,42 @@
+from flask import Flask, render_template, request, redirect, url_for
+import sqlite3
+
+app = Flask(__name__)
+
+def init_db():
+    conn = sqlite3.connect('journal.db')
+    c = conn.cursor()
+    c.execute('''CREATE TABLE IF NOT EXISTS entries (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    title TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )''')
+    conn.commit()
+    conn.close()
+
+@app.route('/')
+def index():
+    conn = sqlite3.connect('journal.db')
+    c = conn.cursor()
+    c.execute('SELECT id, title, content, created FROM entries ORDER BY created DESC')
+    entries = c.fetchall()
+    conn.close()
+    return render_template('journal_index.html', entries=entries)
+
+@app.route('/new', methods=['GET', 'POST'])
+def new_entry():
+    if request.method == 'POST':
+        title = request.form['title']
+        content = request.form['content']
+        conn = sqlite3.connect('journal.db')
+        c = conn.cursor()
+        c.execute('INSERT INTO entries (title, content) VALUES (?, ?)', (title, content))
+        conn.commit()
+        conn.close()
+        return redirect(url_for('index'))
+    return render_template('journal_new.html')
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/templates/journal_index.html
+++ b/templates/journal_index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Journal Entries</title>
+</head>
+<body>
+    <h1>Journal Entries</h1>
+    <a href="{{ url_for('new_entry') }}">New Entry</a>
+    <ul>
+        {% for id, title, content, created in entries %}
+        <li>
+            <h2>{{ title }}</h2>
+            <small>{{ created }}</small>
+            <p>{{ content }}</p>
+        </li>
+        {% else %}
+        <li>No entries yet.</li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/templates/journal_new.html
+++ b/templates/journal_new.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>New Entry</title>
+</head>
+<body>
+    <h1>New Journal Entry</h1>
+    <form method="post">
+        <label for="title">Title:</label><br>
+        <input type="text" id="title" name="title" required><br>
+        <label for="content">Content:</label><br>
+        <textarea id="content" name="content" rows="4" cols="50" required></textarea><br>
+        <input type="submit" value="Save">
+    </form>
+    <a href="{{ url_for('index') }}">Back to entries</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `journal_app.py` with SQLite backend
- add templates for listing and creating journal entries

## Testing
- `python3 -m py_compile journal_app.py`
- `python3 journal_app.py & sleep 5; pkill -f journal_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684ef1cdd5208320a4e9c99dfc2c230b